### PR TITLE
Add missing crossreference for ICLP 1988

### DIFF
--- a/ref.bib
+++ b/ref.bib
@@ -326,7 +326,18 @@
   biburl    = {http://dblp.org/rec/bib/conf/iclp/GelfondL88},
   bibsource = {dblp computer science bibliography, http://dblp.org}
 }
-
+@proceedings{DBLP:conf/iclp/1988,
+  editor    = {Robert A. Kowalski and
+               Kenneth A. Bowen},
+  title     = {Logic Programming, Proceedings of the Fifth International Conference
+               and Symposium, Seattle, Washington, August 15-19, 1988 {(2} Volumes)},
+  publisher = {{MIT} Press},
+  year      = {1988},
+  isbn      = {0-262-61056-6},
+  timestamp = {Fri, 29 Nov 2013 14:57:24 +0100},
+  biburl    = {http://dblp.org/rec/bib/conf/iclp/1988},
+  bibsource = {dblp computer science bibliography, http://dblp.org}
+}
 @article{sldnf,
   author    = {Robert F. St{\"{a}}rk},
   title     = {A Direct Proof of the Completeness of SLDNF-Resolution},


### PR DESCRIPTION
Every time you make a crossreference to a nonexisting reference a cute kitten gets hurt.